### PR TITLE
fix: resolve GitHub Actions CI failures

### DIFF
--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -91,15 +91,17 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt update
-            apt install -y libclang-dev build-essential python3 python3-pip python3-venv curl
+            apt install -y libclang-dev build-essential curl
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-            python3 -m venv /root/venv
-            /root/venv/bin/pip install maturin
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+            uv python install 3.10
+            uv pip install maturin
           run: |
             source $HOME/.cargo/env
             cd pyrsolace
-            /root/venv/bin/maturin build --release --out dist --find-interpreter
+            uv run maturin build --release --out dist --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -95,11 +95,13 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
             curl -LsSf https://astral.sh/uv/install.sh | sh
-            echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bashrc
+            export PATH="$HOME/.local/bin:$PATH"
             uv python install 3.10
-            uv pip install maturin
+            uv tool install maturin
           run: |
             source $HOME/.cargo/env
+            export PATH="$HOME/.local/bin:$PATH"
             cd pyrsolace
             uv run maturin build --release --out dist --find-interpreter
       - name: Upload wheels

--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -87,14 +87,14 @@ jobs:
       - uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu24.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           install: |
             apt update
-            apt install -y libclang-dev build-essential python3 python3-pip curl
+            apt install -y libclang-dev build-essential python3 python3-pip python3-venv curl
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-            pip install maturin
+            python3 -m pip install --break-system-packages maturin
           run: |
             source $HOME/.cargo/env
             cd pyrsolace
@@ -119,13 +119,15 @@ jobs:
       - name: Set up Clang
         uses: egor-tensin/setup-clang@v1
         with:
-          version: latest
+          version: "15"
           platform: ${{ matrix.target }}
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          LIBCLANG_PATH: C:\Program Files\LLVM\bin
         with:
           working-directory: pyrsolace
           target: ${{ matrix.target }}

--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -124,18 +124,13 @@ jobs:
       - name: Set up Clang
         uses: egor-tensin/setup-clang@v1
         with:
-          version: "11"
+          version: "latest"
           platform: ${{ matrix.target }}
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
-        env:
-          LIBCLANG_PATH: C:\Program Files\LLVM\bin
-          BINDGEN_EXTRA_CLANG_ARGS: "${{ matrix.target == 'x64' && '--target=x86_64-pc-windows-msvc' || '--target=i686-pc-windows-msvc' }} -fms-compatibility-version=19"
-          CC: clang
-          CXX: clang++
         with:
           working-directory: pyrsolace
           target: ${{ matrix.target }}

--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64]
+        target: [x64, x86]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -133,7 +133,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         env:
           LIBCLANG_PATH: C:\Program Files\LLVM\bin
-          BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc -fms-compatibility-version=19"
+          BINDGEN_EXTRA_CLANG_ARGS: "${{ matrix.target == 'x64' && '--target=x86_64-pc-windows-msvc' || '--target=i686-pc-windows-msvc' }} -fms-compatibility-version=19"
           CC: clang
           CXX: clang++
         with:

--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [x86_64]
@@ -94,11 +94,12 @@ jobs:
             apt install -y libclang-dev build-essential python3 python3-pip python3-venv curl
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-            python3 -m pip install --break-system-packages maturin
+            python3 -m venv /root/venv
+            /root/venv/bin/pip install maturin
           run: |
             source $HOME/.cargo/env
             cd pyrsolace
-            maturin build --release --out dist --find-interpreter
+            /root/venv/bin/maturin build --release --out dist --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -119,7 +120,7 @@ jobs:
       - name: Set up Clang
         uses: egor-tensin/setup-clang@v1
         with:
-          version: "15"
+          version: "11"
           platform: ${{ matrix.target }}
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -128,7 +129,9 @@ jobs:
         uses: PyO3/maturin-action@v1
         env:
           LIBCLANG_PATH: C:\Program Files\LLVM\bin
-          BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc"
+          BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc -fms-compatibility-version=19"
+          CC: clang
+          CXX: clang++
         with:
           working-directory: pyrsolace
           target: ${{ matrix.target }}

--- a/.github/workflows/pyrsolace-ci.yml
+++ b/.github/workflows/pyrsolace-ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        target: [x86_64] #aarch64
+        target: [x86_64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -109,7 +109,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [x64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -128,6 +128,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         env:
           LIBCLANG_PATH: C:\Program Files\LLVM\bin
+          BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc"
         with:
           working-directory: pyrsolace
           target: ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,25 +61,22 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
- "which",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -87,6 +84,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -381,7 +384,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -611,6 +614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,12 +652,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -828,12 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,19 +859,19 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.6"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -937,7 +937,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -950,7 +950,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -983,7 +983,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -992,7 +992,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1125,9 +1125,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1406,7 +1406,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1459,7 +1459,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1595,7 +1595,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -1629,7 +1629,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1667,17 +1667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/rsolace-sys/Cargo.toml
+++ b/rsolace-sys/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Yvictor/rsolace"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.72.0"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 tar = "0.4.38"
 flate2 = "1.0.26"

--- a/rsolace-sys/Cargo.toml
+++ b/rsolace-sys/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Yvictor/rsolace"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = "0.70.1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 tar = "0.4.38"
 flate2 = "1.0.26"

--- a/rsolace-sys/build.rs
+++ b/rsolace-sys/build.rs
@@ -171,10 +171,6 @@ fn main() {
         // .dynamic_link_require_all(true)
         .size_t_is_usize(true)
         .generate_comments(false)
-        // .blocklist_type("_Complex.*_Float16.*")
-        // .blocklist_type("_Float16")
-        // .blocklist_item(".*_Float16.*")
-        // .blocklist_item(".*__float128.*")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         // .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/rsolace-sys/build.rs
+++ b/rsolace-sys/build.rs
@@ -171,10 +171,10 @@ fn main() {
         // .dynamic_link_require_all(true)
         .size_t_is_usize(true)
         .generate_comments(false)
-        .blocklist_type("_Complex.*_Float16.*")
-        .blocklist_type("_Float16")
-        .blocklist_item(".*_Float16.*")
-        .blocklist_item(".*__float128.*")
+        // .blocklist_type("_Complex.*_Float16.*")
+        // .blocklist_type("_Float16")
+        // .blocklist_item(".*_Float16.*")
+        // .blocklist_item(".*__float128.*")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         // .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/rsolace-sys/build.rs
+++ b/rsolace-sys/build.rs
@@ -171,6 +171,8 @@ fn main() {
         // .dynamic_link_require_all(true)
         .size_t_is_usize(true)
         .generate_comments(false)
+        .blocklist_type("_Float16")
+        .blocklist_type("__float128")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         // .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/rsolace-sys/build.rs
+++ b/rsolace-sys/build.rs
@@ -171,8 +171,10 @@ fn main() {
         // .dynamic_link_require_all(true)
         .size_t_is_usize(true)
         .generate_comments(false)
+        .blocklist_type("_Complex.*_Float16.*")
         .blocklist_type("_Float16")
-        .blocklist_type("__float128")
+        .blocklist_item(".*_Float16.*")
+        .blocklist_item(".*__float128.*")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         // .parse_callbacks(Box::new(bindgen::CargoCallbacks))


### PR DESCRIPTION
## Summary
- Fix Linux ARM build by using Ubuntu 22.04 instead of 20.04
- Update bindgen to 0.72 to fix Windows

## Test plan
- [x] CI builds should pass for all platforms
- [x] Linux ARM builds should complete without pip errors
- [x] Windows builds should complete without bindgen panics
- [x] Windows x86 builds should work alongside x64 builds

🤖 Generated with [Claude Code](https://claude.ai/code)