### PR TITLE
fix: modify_client_info awaits MODIFYPROP_OK event before returning (#8)

### DIFF
--- a/rsolace/src/solclient.rs
+++ b/rsolace/src/solclient.rs
@@ -5,7 +5,7 @@ use super::solmsg::{SolMsg, SolMsgError};
 pub use super::solprops::SessionProps;
 use super::types::{
     ErrorInfo, SolClientCacheRequestFlags, SolClientLogLevel, SolClientReturnCode,
-    SolClientSubscribeFlags,
+    SolClientSessionEvent, SolClientSubscribeFlags,
 };
 use super::utils::ConvertToCString;
 use dashmap::DashMap;
@@ -18,13 +18,22 @@ use std::option::Option;
 use std::os::raw::c_char;
 use std::pin::Pin;
 use std::ptr::{null, null_mut};
+use std::time::Duration;
 // TODO fn pointer to struct
 #[cfg(feature = "channel")]
 use kanal::{bounded, unbounded, Receiver, Sender};
 // Async kanal imports for future async support
 #[cfg(all(feature = "channel", feature = "tokio"))]
 use kanal::{bounded_async, AsyncReceiver, AsyncSender};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+
+/// Maximum time `modify_client_info` will wait for the asynchronous
+/// `SOLCLIENT_SESSION_EVENT_MODIFYPROP_OK` / `_FAIL` confirmation.
+///
+/// Matches Solace's documented default of
+/// `SOLCLIENT_SESSION_PROP_DEFAULT_MODIFYPROP_TIMEOUT_MS = 10000`.
+const MODIFY_CLIENT_INFO_TIMEOUT_MS: u64 = 10_000;
 // #[cfg_attr(feature = "tokio", derive(Debug, Clone))]
 
 #[derive(Debug, Snafu, PartialEq)]
@@ -140,6 +149,17 @@ struct SolClientInner {
     #[cfg(all(feature = "channel", feature = "tokio"))]
     // async_request_reply_map: Arc<DashMap<String, AsyncSender<SolMsg>>>,
     async_request_reply_map: DashMap<String, AsyncSender<SolMsg>>,
+    /// Monotonic counter used to generate unique correlation tags for
+    /// non-blocking session-modify operations. Starts at 1 so a `null`
+    /// correlation pointer is always distinguishable from a valid tag.
+    #[cfg(feature = "channel")]
+    next_modify_prop_tag: AtomicUsize,
+    /// One-shot waiters keyed by correlation tag for in-flight
+    /// `solClient_session_modifyClientInfo` calls. The event callback
+    /// resolves the matching waiter with the `ModifyPropOk` /
+    /// `ModifyPropFail` outcome reported by the C API.
+    #[cfg(feature = "channel")]
+    modify_prop_waiters: DashMap<usize, Sender<SolClientSessionEvent>>,
 }
 
 pub struct SolClient {
@@ -179,6 +199,11 @@ impl SolClient {
         self.inner().request_reply_map.clear();
         #[cfg(all(feature = "channel", feature = "tokio"))]
         self.inner().async_request_reply_map.clear();
+        // Drop any pending modify_client_info waiters. Dropping the senders
+        // closes the channels so `recv_timeout` returns immediately instead
+        // of blocking the full 10s when the session is torn down.
+        #[cfg(feature = "channel")]
+        self.inner().modify_prop_waiters.clear();
     }
 
     pub fn new(log_level: SolClientLogLevel) -> Result<SolClient, SolClientError> {
@@ -257,6 +282,12 @@ impl SolClient {
                 #[cfg(all(feature = "channel", feature = "tokio"))]
                 // async_request_reply_map: Arc::new(DashMap::new()),
                 async_request_reply_map: DashMap::new(),
+                #[cfg(feature = "channel")]
+                // Start at 1 — 0 would round-trip to a null pointer and be
+                // indistinguishable from "no correlation supplied".
+                next_modify_prop_tag: AtomicUsize::new(1),
+                #[cfg(feature = "channel")]
+                modify_prop_waiters: DashMap::new(),
             };
 
             Ok(SolClient {
@@ -370,7 +401,7 @@ impl SolClient {
                     #[cfg(feature = "raw")]
                     {
                         if let Some(cb) = self_ref.rx_event_callback {
-                            cb(self_ref, event)
+                            cb(self_ref, event.clone())
                         } else {
                             tracing::info!(
                                 "event: {}, response code: {}, info: {}",
@@ -382,6 +413,33 @@ impl SolClient {
                     }
                     #[cfg(feature = "channel")]
                     {
+                        // Dispatch ModifyPropOk / ModifyPropFail to any
+                        // in-flight modify_client_info waiter keyed by the
+                        // correlation tag we supplied. Always still forward
+                        // the event downstream so observers on the public
+                        // event channel can see modify-prop outcomes too.
+                        if matches!(
+                            event.session_event,
+                            SolClientSessionEvent::ModifyPropOk
+                                | SolClientSessionEvent::ModifyPropFail
+                        ) {
+                            if let Some(tag) = event.correlation_tag {
+                                if let Some((_tag, sender)) =
+                                    self_ref.modify_prop_waiters.remove(&tag)
+                                {
+                                    // bounded(1) — try_send avoids any
+                                    // possibility of blocking the C API
+                                    // context thread if the waiter has gone
+                                    // away.
+                                    if let Err(e) = sender.try_send(event.session_event) {
+                                        tracing::error!(
+                                            "modify_client_info waiter try_send error: {:?}",
+                                            e
+                                        );
+                                    }
+                                }
+                            }
+                        }
                         if let Err(e) = self_ref.event_sender.send(event) {
                             tracing::error!("send event to channel error: {}", e);
                         }
@@ -796,15 +854,50 @@ impl SolClient {
         SolClientReturnCode::from_i32(rt_code).unwrap()
     }
 
+    /// Modify the `APPLICATION_DESCRIPTION` and/or `CLIENT_NAME` of the
+    /// current Session and synchronously wait for the broker confirmation.
+    ///
+    /// Internally this issues the modify in the C API's **non-blocking**
+    /// mode (no `SOLCLIENT_MODIFYPROP_FLAGS_WAITFORCONFIRM`) with a
+    /// per-call correlation tag, then awaits the matching
+    /// `SOLCLIENT_SESSION_EVENT_MODIFYPROP_OK` /
+    /// `SOLCLIENT_SESSION_EVENT_MODIFYPROP_FAIL` event before returning.
+    ///
+    /// The previous implementation used `WAITFORCONFIRM`, which the C API
+    /// would consume internally — the public event callback never saw the
+    /// MODIFYPROP_OK event, and the call returned as soon as the broker
+    /// acknowledged receipt of the modify request, not when the in-API
+    /// P2P-subscription migration had finished. That left a race window
+    /// (~0–3 s) where the next `send_request` could time out because the
+    /// new client name's reply-to subscription wasn't yet active.
+    /// See <https://github.com/Yvictor/rsolace/issues/8>.
+    ///
+    /// Returns `SolClientReturnCode::Ok` on `ModifyPropOk`,
+    /// `SolClientReturnCode::Fail` on `ModifyPropFail` or on internal
+    /// timeout, and the C API's return code on any synchronous failure
+    /// (e.g. the call was rejected before being dispatched).
+    ///
+    /// # Threading
+    ///
+    /// This call MUST NOT be invoked from within the Solace API context
+    /// thread itself (e.g. from inside a message or event callback);
+    /// doing so would deadlock because the event callback delivering the
+    /// confirmation runs on that same context thread. rsolace's normal
+    /// calling pattern (application thread / tokio runtime) is fine.
     pub fn modify_client_info(
         &mut self,
         app_description: Option<&str>,
         client_name: Option<&str>,
     ) -> SolClientReturnCode {
+        // Keep the CStrings alive for the duration of the C call — the
+        // raw pointers we hand to the C API are only valid while these
+        // owners are in scope.
+        let app_desc_c = app_description.map(|s| CString::new(s).unwrap());
+        let client_name_c = client_name.map(|s| CString::new(s).unwrap());
+
         let mut client_info_props = Vec::<*const c_char>::new();
 
-        if let Some(app_desc) = app_description {
-            let app_desc = CString::new(app_desc).unwrap();
+        if let Some(ref app_desc) = app_desc_c {
             client_info_props.push(
                 rsolace_sys::SOLCLIENT_SESSION_PROP_APPLICATION_DESCRIPTION.as_ptr()
                     as *const c_char,
@@ -812,26 +905,108 @@ impl SolClient {
             client_info_props.push(app_desc.as_ptr());
         }
 
-        if let Some(name) = client_name {
-            let name_ptr = CString::new(name).unwrap();
+        if let Some(ref name) = client_name_c {
             client_info_props
                 .push(rsolace_sys::SOLCLIENT_SESSION_PROP_CLIENT_NAME.as_ptr() as *const c_char);
-            client_info_props.push(name_ptr.as_ptr());
+            client_info_props.push(name.as_ptr());
         }
         if client_info_props.is_empty() {
             return SolClientReturnCode::NotFound;
         }
-        client_info_props.push(std::ptr::null_mut());
+        client_info_props.push(std::ptr::null());
 
-        let rt_code = unsafe {
-            rsolace_sys::solClient_session_modifyClientInfo(
-                self.inner().session_p,
-                client_info_props.as_mut_ptr(),
-                rsolace_sys::SOLCLIENT_MODIFYPROP_FLAGS_WAITFORCONFIRM,
-                std::ptr::null_mut(),
-            )
-        };
-        SolClientReturnCode::from_i32(rt_code).unwrap()
+        // Without the `channel` feature there is no waiter-map mechanism;
+        // fall back to the previous blocking behaviour. Consumers without
+        // the channel feature don't get the race fix — but they also
+        // don't have the infrastructure for the async path.
+        #[cfg(not(feature = "channel"))]
+        {
+            let rt_code = unsafe {
+                rsolace_sys::solClient_session_modifyClientInfo(
+                    self.inner().session_p,
+                    client_info_props.as_mut_ptr(),
+                    rsolace_sys::SOLCLIENT_MODIFYPROP_FLAGS_WAITFORCONFIRM,
+                    std::ptr::null_mut(),
+                )
+            };
+            return SolClientReturnCode::from_i32(rt_code).unwrap();
+        }
+
+        #[cfg(feature = "channel")]
+        {
+            // Allocate a unique correlation tag and register a one-shot
+            // waiter BEFORE issuing the C call, so we never race the
+            // event callback that may fire as soon as the call returns.
+            let tag = self
+                .inner()
+                .next_modify_prop_tag
+                .fetch_add(1, Ordering::Relaxed);
+            let (sender, receiver) = bounded::<SolClientSessionEvent>(1);
+            self.inner().modify_prop_waiters.insert(tag, sender);
+
+            let rt_code = unsafe {
+                rsolace_sys::solClient_session_modifyClientInfo(
+                    self.inner().session_p,
+                    client_info_props.as_mut_ptr(),
+                    // Non-blocking mode: the C API will deliver the
+                    // outcome via SOLCLIENT_SESSION_EVENT_MODIFYPROP_OK /
+                    // MODIFYPROP_FAIL with our `correlation_p` returned
+                    // verbatim. With WAITFORCONFIRM set, the C API would
+                    // consume the confirmation internally and our event
+                    // callback would never see it.
+                    0,
+                    tag as *mut c_void,
+                )
+            };
+            let rt_code = SolClientReturnCode::from_i32(rt_code).unwrap();
+
+            // The C API may return either OK or IN_PROGRESS to indicate
+            // "request was queued, async confirmation will follow".
+            // Anything else is a synchronous failure (e.g. NOT_READY,
+            // WOULD_BLOCK, FAIL) — no event will arrive, so don't wait.
+            if rt_code != SolClientReturnCode::Ok && rt_code != SolClientReturnCode::InProgress {
+                self.inner().modify_prop_waiters.remove(&tag);
+                return rt_code;
+            }
+
+            // Block until the matching MODIFYPROP_OK / _FAIL event fires
+            // on the context thread, or we hit the documented Solace
+            // default modify-prop timeout.
+            let result =
+                receiver.recv_timeout(Duration::from_millis(MODIFY_CLIENT_INFO_TIMEOUT_MS));
+            // Ensure the waiter entry is gone on every path (timeout,
+            // success, channel-closed). Drop is normally enough, but
+            // belt-and-braces against the channel being resolved twice.
+            self.inner().modify_prop_waiters.remove(&tag);
+
+            match result {
+                Ok(SolClientSessionEvent::ModifyPropOk) => SolClientReturnCode::Ok,
+                Ok(SolClientSessionEvent::ModifyPropFail) => {
+                    tracing::warn!(
+                        "modify_client_info: broker returned MODIFYPROP_FAIL (tag={})",
+                        tag
+                    );
+                    SolClientReturnCode::Fail
+                }
+                Ok(other) => {
+                    // Should never happen — only OK/FAIL are dispatched.
+                    tracing::error!(
+                        "modify_client_info: unexpected event variant {:?} (tag={})",
+                        other,
+                        tag
+                    );
+                    SolClientReturnCode::Fail
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "modify_client_info: timed out or channel closed waiting for MODIFYPROP confirmation (tag={}, err={:?})",
+                        tag,
+                        e
+                    );
+                    SolClientReturnCode::Fail
+                }
+            }
+        }
     }
 
     pub fn get_ptr(&self) -> *const c_void {
@@ -930,11 +1105,7 @@ mod tests {
         let msg = SolMsg::new().unwrap();
         assert!(client.inner().msg_sender.send(msg).is_ok());
 
-        let event = SolEvent::new(
-            crate::types::SolClientSessionEvent::UpNotice,
-            0,
-            "test",
-        );
+        let event = SolEvent::new(crate::types::SolClientSessionEvent::UpNotice, 0, "test");
         assert!(client.inner().event_sender.send(event).is_ok());
 
         // Receivers should get the messages we just sent

--- a/rsolace/src/solevent.rs
+++ b/rsolace/src/solevent.rs
@@ -8,7 +8,15 @@ pub struct SolEvent {
     pub session_event: SolClientSessionEvent,
     pub response_code: u32,
     pub info: String,
-    // correlation: String,
+    /// Application-supplied correlation tag passed back by the C API in
+    /// asynchronous Session-event confirmations (e.g.
+    /// `SOLCLIENT_SESSION_EVENT_MODIFYPROP_OK` /
+    /// `SOLCLIENT_SESSION_EVENT_MODIFYPROP_FAIL`). Stored as a `usize`
+    /// because the underlying C field is `void *` and rsolace uses the
+    /// pointer as an opaque numeric handle into an internal waiter map.
+    /// `None` when the C API did not provide a correlation pointer for
+    /// this event.
+    pub correlation_tag: Option<usize>,
 }
 
 #[derive(Debug, Snafu)]
@@ -27,6 +35,7 @@ impl SolEvent {
             session_event,
             response_code,
             info: info.to_string(),
+            correlation_tag: None,
         }
     }
 
@@ -44,10 +53,21 @@ impl SolEvent {
             .context(InfoUtf8Snafu)?
             .to_owned();
 
+        // The C API forwards back the `void *correlation_p` we passed into
+        // the originating non-blocking call (e.g. modifyClientInfo). rsolace
+        // uses the pointer as an opaque numeric tag, so reinterpret it as
+        // a `usize`. A null pointer means "no correlation supplied".
+        let correlation_tag = if event.correlation_p.is_null() {
+            None
+        } else {
+            Some(event.correlation_p as usize)
+        };
+
         Ok(SolEvent {
             session_event: event.sessionEvent.into(),
             response_code: event.responseCode,
             info,
+            correlation_tag,
         })
     }
 

--- a/rsolace/tests/modify_client_info.rs
+++ b/rsolace/tests/modify_client_info.rs
@@ -1,0 +1,149 @@
+//! Integration tests for [`SolClient::modify_client_info`].
+//!
+//! These tests exercise the issue-#8 fix: `modify_client_info` must not
+//! return until the broker has confirmed the property change (i.e. the
+//! `SOLCLIENT_SESSION_EVENT_MODIFYPROP_OK` event has fired and the P2P
+//! topic migration is complete). Before the fix, calling
+//! `send_request_async` immediately after `modify_client_info` could
+//! intermittently time out for up to ~3 s.
+//!
+//! All tests in this file talk to a real Solace broker and are gated on
+//! the same env vars used elsewhere in the project:
+//!
+//! ```text
+//! SOLACE_HOST     e.g. "tcp://localhost:55555"
+//! SOLACE_VPN
+//! SOLACE_USERNAME
+//! SOLACE_PASSWORD
+//! ```
+//!
+//! They also require a peer service responding on
+//! `SOLACE_MODIFY_REPLY_TOPIC` (default `api/v1/ping`) so the
+//! send_request_async path has something to reply. Without a replier the
+//! "no race" assertion can't be made and the test would be meaningless,
+//! so the tests are `#[ignore]` by default. Run them manually with:
+//!
+//! ```bash
+//! cargo test -p rsolace --test modify_client_info -- --ignored --nocapture
+//! ```
+
+use std::time::Duration;
+
+use rsolace::solclient::SolClient;
+use rsolace::solmsg::SolMsg;
+use rsolace::types::{SolClientLogLevel, SolClientReturnCode};
+use rsolace::SessionProps;
+
+fn env_or_skip(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+fn live_session_props(initial_client_name: &str) -> Option<SessionProps> {
+    let host = env_or_skip("SOLACE_HOST")?;
+    let vpn = env_or_skip("SOLACE_VPN")?;
+    let username = env_or_skip("SOLACE_USERNAME")?;
+    let password = env_or_skip("SOLACE_PASSWORD")?;
+    Some(
+        SessionProps::default()
+            .host(&host)
+            .vpn(&vpn)
+            .username(&username)
+            .password(&password)
+            .client_name(initial_client_name)
+            .reapply_subscriptions(true)
+            .connect_retries(1)
+            .connect_timeout_ms(5000)
+            .compression_level(0),
+    )
+}
+
+/// Smoke test: after `modify_client_info` returns Ok, a subsequent
+/// `send_request_async` to a known replier must complete within 5s.
+/// Loops 10 times so any non-deterministic race window has a fair
+/// chance to manifest.
+#[test]
+#[ignore = "requires live Solace broker + replier; run with --ignored"]
+fn modify_client_info_then_request_no_race() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_test_writer()
+        .try_init();
+
+    let _ = dotenvy::dotenv();
+
+    let reply_topic =
+        std::env::var("SOLACE_MODIFY_REPLY_TOPIC").unwrap_or_else(|_| "api/v1/ping".to_string());
+
+    let props = match live_session_props("rsolace-modify-test") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "skipping: SOLACE_HOST/VPN/USERNAME/PASSWORD not set; run with --ignored after exporting them"
+            );
+            return;
+        }
+    };
+
+    let mut client = SolClient::new(SolClientLogLevel::Notice).expect("SolClient::new");
+    let connected = client.connect(props);
+    assert!(connected, "failed to connect to broker");
+
+    // Give the API a beat to finish session-up bookkeeping.
+    std::thread::sleep(Duration::from_millis(200));
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    for i in 0..10 {
+        let new_name = format!("rsolace-modify-test-{}", i);
+        let rc = client.modify_client_info(None, Some(&new_name));
+        assert_eq!(
+            rc,
+            SolClientReturnCode::Ok,
+            "iteration {}: modify_client_info({}) returned {:?}",
+            i,
+            new_name,
+            rc
+        );
+
+        let mut msg = SolMsg::new().expect("SolMsg::new");
+        msg.set_topic(&reply_topic);
+        msg.set_delivery_to_one(true);
+
+        // 5s upper bound for the round-trip. With the fix, this should
+        // succeed on every iteration. Without the fix, the first
+        // ~0-3s after modify_client_info can drop replies because the
+        // P2P subscription for the new client_name hasn't migrated yet.
+        let reply = runtime.block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), client.send_request_async(&msg)).await
+        });
+
+        match reply {
+            Ok(Ok(_msg)) => {
+                tracing::info!(iteration = i, "request/reply ok");
+            }
+            Ok(Err(e)) => panic!("iteration {}: send_request_async error: {:?}", i, e),
+            Err(_elapsed) => panic!(
+                "iteration {}: send_request_async timed out (5s); modify_client_info race not fixed",
+                i
+            ),
+        }
+    }
+
+    client.disconnect();
+}
+
+/// Negative path: a `modify_client_info` call with no fields supplied
+/// must fail fast (NotFound) without registering or leaking a waiter.
+/// This test does not require a broker.
+#[test]
+fn modify_client_info_no_props_returns_not_found() {
+    let mut client = SolClient::new(SolClientLogLevel::Notice).expect("SolClient::new");
+    let rc = client.modify_client_info(None, None);
+    assert_eq!(rc, SolClientReturnCode::NotFound);
+}


### PR DESCRIPTION
## Summary

Fixes #8.

**Problem.** `SolClient::modify_client_info` was calling the C API with `SOLCLIENT_MODIFYPROP_FLAGS_WAITFORCONFIRM`, which causes the Solace SDK to consume the `SOLCLIENT_SESSION_EVENT_MODIFYPROP_OK` confirmation internally. The call returned ~166ms after the broker acked receipt of the modify request, but the C API's internal P2P-subscription migration to the new `CLIENT_NAME` continued asynchronously for up to ~3s afterwards. Any `send_request_async` issued in that window could intermittently time out because the new reply-to subscription wasn't active yet.

**Fix.** Switch to the C API's non-blocking mode (`flag = 0`) with a per-call correlation tag, register a one-shot waiter keyed by that tag on `SolClientInner`, and block in `modify_client_info` until the matching `MODIFYPROP_OK` / `MODIFYPROP_FAIL` event arrives via `event_receive_callback`. The wait honors the Solace SDK's documented default `SOLCLIENT_SESSION_PROP_DEFAULT_MODIFYPROP_TIMEOUT_MS = 10000`. Public signature is unchanged; the `channel` feature gates the new async path (no-`channel` builds fall back to the old `WAITFORCONFIRM` behavior).

Also fixes a pre-existing dangling-pointer bug in the same function: `CString` temporaries went out of scope before the `solClient_session_modifyClientInfo` call, leaving the pushed `as_ptr()`s pointing at freed memory.

## Implementation notes

- `SolEvent` gains a `correlation_tag: Option<usize>` field surfaced from `solClient_session_eventCallbackInfo.correlation_p`. The tag is cast through `usize` because the SDK exposes the slot as `void *` and we use it as an opaque numeric handle.
- `SolClientInner` gains `next_modify_prop_tag: AtomicUsize` (starts at 1 so 0 stays unambiguous) and `modify_prop_waiters: DashMap<usize, Sender<SolClientSessionEvent>>`. Both are cleared in `destroy_session()` so a torn-down session doesn't leak waiters.
- `event_receive_callback` dispatches `ModifyPropOk` / `ModifyPropFail` to the waiter map (when a tag is present) using `try_send` on a `bounded(1)` channel — never blocks the SDK context thread. The event is still forwarded to the public `event_sender` so external observers continue to see modify-prop events.

## Downstream impact

Unblocks the rshioaji-side report at http://128.110.22.98/ec666/shioaji/-/issues/138 (intermittent request timeouts immediately after login when the client renames itself). Verified there that with `WAITFORCONFIRM`, `MODIFYPROP_OK` never reaches the public event channel in 5/5 fresh logins.

## Test plan

- [x] `cargo check -p rsolace`
- [x] `cargo fmt --check` on the three changed files
- [x] `cargo test -p rsolace --lib` — 57 passed, 0 failed
- [x] `cargo test -p rsolace --test modify_client_info` — 1 passed (negative path), 1 ignored (live-broker)
- [ ] `cargo test -p rsolace --test modify_client_info -- --ignored --nocapture` against a real broker (requires `SOLACE_HOST` / `SOLACE_VPN` / `SOLACE_USERNAME` / `SOLACE_PASSWORD`, and a replier on `SOLACE_MODIFY_REPLY_TOPIC`, default `api/v1/ping`). Loops modify+request 10 times to surface any residual race.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>